### PR TITLE
Terraformized the initial Vagrant setup and added documentation for setup

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -9,19 +9,19 @@ then
 	echo "$(java -version)"
 else
 	echo "Installing Java.."
-	tar -xf /vagrant/usbstick/jdk-7u75-linux-x64.gz -C /vagrant/usbstick
-	ln -sf /vagrant/usbstick/jdk1.7.0_75/bin/java /usr/bin/java
+	tar -xf ~/petclinic/usbstick/jdk-7u80-linux-x64.tar.gz -C ~/petclinic/usbstick
+	ln -sf ~/petclinic/usbstick/jdk1.7.0_80/bin/java /usr/bin/java
 fi
 
 if [ -n "$(grep "JAVA_HOME" /etc/bash.bashrc)" ]
-then 
+then
 	echo "JAVA_HOME found in /etc/bash.bashrc"
 else
 	echo "Adding JAVA_HOME to /etc/bash.bashrc.."
-	echo "export JAVA_HOME=/vagrant/usbstick/jdk1.7.0_75" >> /etc/bash.bashrc	
+	echo "export JAVA_HOME=~/petclinic/usbstick/jdk1.7.0_80" >> /etc/bash.bashrc
 fi
 
-export JAVA_HOME=/vagrant/usbstick/jdk1.7.0_75
+export JAVA_HOME=~/petclinic/usbstick/jdk1.7.0_80/
 
 if [ -n "$(which mvn | grep /usr/bin/mvn)" ]
 then
@@ -29,9 +29,12 @@ then
 	echo "$(mvn --version)"
 else
 	echo "Installing Maven.."
-	tar -xf /vagrant/usbstick/apache-maven-3.2.5-bin.tar.gz -C /vagrant/usbstick
-	ln -sf /vagrant/usbstick/apache-maven-3.2.5/bin/mvn /usr/bin/mvn
+	tar -xf ~/petclinic/usbstick/apache-maven-3.2.5-bin.tar.gz -C ~/petclinic/usbstick
+	ln -sf ~/petclinic/usbstick/apache-maven-3.2.5/bin/mvn /usr/bin/mvn
 fi
+
+echo "Setting up server"
+mvn -f ~/petclinic/pom_provision_demo.xml tomcat7:run
 
 echo "Provisioning Run Complete"
 date

--- a/terraform-setup-readme.md
+++ b/terraform-setup-readme.md
@@ -1,0 +1,28 @@
+1. Obtain an AWS private key using these instructions (if you don't have one already): http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair
+  - Make sure to name the key-pair "spring-petclinic" without quotes
+  - Also, save the .pem file in this directory
+2. Obtain your AWS access key and secret access key here (if you don't have them already):
+  - https://console.aws.amazon.com/iam/home?#/security_credential
+3. Open variables.tf and modify the variables "access_key" and "secret_key" with their respective values from step 2
+4. Set a security group for future network connections:
+  - Navigate to AWS console
+  - Click on "EC2"
+  - Click on "Security Groups"
+  - Select default security group (group name "default"); at the bottom of the web page, there should be 4 tabs labelled "Description", "Inbound", "Outbound", "Tags"
+  - Select the "Inbound" tab
+  - Click "Edit"
+  - Click "Add Rule"
+  - For this new rule, set Type to "All TCP"
+    - For Source, if you want anybody to have a connection, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you want some other specific IP, select "Custom" and enter the IP
+  - Click "Save"
+4. Open terminal and run "terraform init" from this directory
+5. Then, run "terraform apply"
+6. Setup will create an AWS EC2 instance with 64-bit Linux (takes anywhere from 1-4 minutes).
+  - First, it will copy all the files in this directory to the instance.
+  - Next, it will run provision.sh.
+    - This script installs Java and Maven and starts up a web server
+  - The web server is finished setting up once the script pauses and you see the line "aws_instance.petclinic (remote-exec): INFO: Starting ProtocolHandler ["http-bio-9966"]" in the terminal
+  - NOTE: Terraform will continue to say "... still creating..." after everything is installed and the server is setup.  This just means the server is listening for requests.
+7. Navigate to the AWS console in your browser, search for EC2, and select the AWS instance you just created.  A public DNS is provided.  
+  - Enter that DNS with ":9966.petclinic" concatenated at the end into your browser.
+8. You are not connected to petclinic!

--- a/tf-setup.tf
+++ b/tf-setup.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+	access_key = "${var.access_key}"
+	secret_key = "${var.secret_key}"
+	region = "${var.region}"
+}
+
+resource "aws_instance" "petclinic" {
+	ami = "${var.ami}"
+	instance_type = "${var.instance_type}"
+	key_name = "spring-petclinic"
+
+	provisioner "remote-exec" {
+		inline = [
+			"mkdir petclinic"
+		]
+
+		connection {
+			type = "ssh"
+			user = "ubuntu"
+			private_key = "${file("spring-petclinic.pem")}"
+		}
+	}
+
+	provisioner "file" {
+		source = "./"
+		destination = "~/petclinic/"
+
+		connection {
+			type = "ssh"
+			user = "ubuntu"
+			private_key = "${file("spring-petclinic.pem")}"
+		}
+	}
+
+	provisioner "remote-exec" {
+		inline = [
+			"sudo bash ./petclinic/provision.sh"
+		]
+
+		connection {
+			type = "ssh"
+			user = "ubuntu"
+			private_key = "${file("spring-petclinic.pem")}"
+		}
+	}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "access_key" { default = "INSERT_ACCESS_KEY_HERE" }
+variable "secret_key" { default = "INSERT_SECRET_ACCESS_KEY_HERE" }
+variable "instance_type" { default = "t1.micro" }
+variable "region" { default = "us-east-1" }
+variable "ami" { default = "ami-408c7f28" }


### PR DESCRIPTION
Initially, this repository used Vagrant to create a box and setup this web application.  This commit replaces the use of Vagrant with Terraform to setup an AWS EC2 instance with 64-bit Linux.  In addition, with the modified provision.sh script, the web application sets itself up automatically so the user doesn't need to ssh into the instance.  

Included with this commit is some basic documentation for Terraform setup.