### PR TITLE
Parallelized server setup and modified documentation for easier user reading

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -34,7 +34,8 @@ else
 fi
 
 echo "Setting up server"
-mvn -f ~/petclinic/pom_provision_demo.xml tomcat7:run
+sudo nohup mvn -f ~/petclinic/pom_provision_demo.xml tomcat7:run &
+sleep 1
 
 echo "Provisioning Run Complete"
 date

--- a/terraform-setup-readme.md
+++ b/terraform-setup-readme.md
@@ -18,7 +18,7 @@
     - For the Source attribute, if you want universal access to the web application, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you only want a specific IP, select "Custom" and enter the IP
   - Click "Save"
 4. Navigate to variables.tf and modify the variable "security_groups" to contain your chosen security groups from step 4.  Simply add their name to the comma-separated list.
-5. Download Java and Maven to the /usbstick/ folders:
+5. Download Java and Maven to the spring-petclinic/usbstick/ folders:
   - Download Linux x64 Java 7_75 tar.gz http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u75-oth-JPR
   - Download Maven http://mirror.nexcess.net/apache/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
 6. Open terminal and run "terraform init" from this directory.

--- a/terraform-setup-readme.md
+++ b/terraform-setup-readme.md
@@ -18,7 +18,7 @@
     - For the Source attribute, if you want universal access to the web application, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you only want a specific IP, select "Custom" and enter the IP
   - Click "Save"
 4. Navigate to variables.tf and modify the variable "security_groups" to contain your chosen security groups from step 4.  Simply add their name to the comma-separated list.
-5. Download Java and Maven to the spring-petclinic/usbstick/ folders:
+5. Download Java and Maven to the spring-petclinic/usbstick/ folder:
   - Download Linux x64 Java 7_75 tar.gz http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u75-oth-JPR
   - Download Maven http://mirror.nexcess.net/apache/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
 6. Open terminal and run "terraform init" from this directory.

--- a/terraform-setup-readme.md
+++ b/terraform-setup-readme.md
@@ -1,28 +1,30 @@
 1. Obtain an AWS private key using these instructions (if you don't have one already): http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair
-  - Make sure to name the key-pair "spring-petclinic" without quotes
-  - Also, save the .pem file in this directory
+  - Name the key-pair "spring-petclinic" without quotes
+  - Save the .pem file in this directory (spring-petclinic)
 2. Obtain your AWS access key and secret access key here (if you don't have them already):
   - https://console.aws.amazon.com/iam/home?#/security_credential
-3. Open variables.tf and modify the variables "access_key" and "secret_key" with their respective values from step 2
-4. Set a security group for future network connections:
+3. Open variables.tf and modify the variables "access_key" and "secret_key" with their respective values from step 2.
+4. Setup a security group for future network connections:
   - Navigate to AWS console
   - Click on "EC2"
   - Click on "Security Groups"
-  - Select default security group (group name "default"); at the bottom of the web page, there should be 4 tabs labelled "Description", "Inbound", "Outbound", "Tags"
+  - Create a security group in order to select inbound and outbound traffic later in the process
+    - Alternatively, use the default security group (group name "default")
+    - At the bottom of the web page, there should be 4 tabs labelled "Description", "Inbound", "Outbound", "Tags" after selecting/clicking the chosen security group
   - Select the "Inbound" tab
   - Click "Edit"
   - Click "Add Rule"
   - For this new rule, set Type to "All TCP"
-    - For Source, if you want anybody to have a connection, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you want some other specific IP, select "Custom" and enter the IP
+    - For the Source attribute, if you want universal access to the web application, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you only want a specific IP, select "Custom" and enter the IP
   - Click "Save"
-4. Open terminal and run "terraform init" from this directory
-5. Then, run "terraform apply"
-6. Setup will create an AWS EC2 instance with 64-bit Linux (takes anywhere from 1-4 minutes).
+4. Navigate to variables.tf and modify the variable "aws_security_groups" to contain your chosen security groups from step 4.  Simply add their name to the comma-separated list.
+5. Open terminal and run "terraform init" from this directory.
+6. Then, enter the command "terraform apply".
+7. Setup will create an AWS EC2 instance with 64-bit Linux (takes anywhere from 1-4 minutes).
   - First, it will copy all the files in this directory to the instance.
   - Next, it will run provision.sh.
-    - This script installs Java and Maven and starts up a web server
-  - The web server is finished setting up once the script pauses and you see the line "aws_instance.petclinic (remote-exec): INFO: Starting ProtocolHandler ["http-bio-9966"]" in the terminal
-  - NOTE: Terraform will continue to say "... still creating..." after everything is installed and the server is setup.  This just means the server is listening for requests.
-7. Navigate to the AWS console in your browser, search for EC2, and select the AWS instance you just created.  A public DNS is provided.  
-  - Enter that DNS with ":9966.petclinic" concatenated at the end into your browser.
-8. You are not connected to petclinic!
+    - This script installs Java + Maven and starts up a web server
+8. Once provision.sh is finished running, the terminal will display an output variable named "url = ".  Copy the following url and enter it into a web browser.  The entire server spends roughly 1 minute 20 seconds on average to present an interface after setting up.
+9. You are now connected to petclinic!
+
+NOTE: To take down the server and aws instance, run "terraform destroy" from this directory in a terminal.

--- a/terraform-setup-readme.md
+++ b/terraform-setup-readme.md
@@ -17,14 +17,17 @@
   - For this new rule, set Type to "All TCP"
     - For the Source attribute, if you want universal access to the web application, select "Anywhere"; if you only want your IP allowed, select "My IP"; if you only want a specific IP, select "Custom" and enter the IP
   - Click "Save"
-4. Navigate to variables.tf and modify the variable "aws_security_groups" to contain your chosen security groups from step 4.  Simply add their name to the comma-separated list.
-5. Open terminal and run "terraform init" from this directory.
-6. Then, enter the command "terraform apply".
-7. Setup will create an AWS EC2 instance with 64-bit Linux (takes anywhere from 1-4 minutes).
+4. Navigate to variables.tf and modify the variable "security_groups" to contain your chosen security groups from step 4.  Simply add their name to the comma-separated list.
+5. Download Java and Maven to the /usbstick/ folders:
+  - Download Linux x64 Java 7_75 tar.gz http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u75-oth-JPR
+  - Download Maven http://mirror.nexcess.net/apache/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
+6. Open terminal and run "terraform init" from this directory.
+7. Then, enter the command "terraform apply".
+8. Setup will create an AWS EC2 instance with 64-bit Linux (takes anywhere from 1-4 minutes).
   - First, it will copy all the files in this directory to the instance.
   - Next, it will run provision.sh.
     - This script installs Java + Maven and starts up a web server
-8. Once provision.sh is finished running, the terminal will display an output variable named "url = ".  Copy the following url and enter it into a web browser.  The entire server spends roughly 1 minute 20 seconds on average to present an interface after setting up.
-9. You are now connected to petclinic!
+9. Once provision.sh is finished running, the terminal will display an output variable named "url = ".  Copy the following url and enter it into a web browser.  The entire server spends roughly 1 minute 20 seconds on average to present an interface after setting up.
+10. You are now connected to petclinic!
 
 NOTE: To take down the server and aws instance, run "terraform destroy" from this directory in a terminal.

--- a/tf-setup.tf
+++ b/tf-setup.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "petclinic" {
 	ami = "${var.ami}"
 	instance_type = "${var.instance_type}"
 	key_name = "spring-petclinic"
+	security_groups = "${var.security_groups}"
 
 	provisioner "remote-exec" {
 		inline = [

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,8 @@ variable "secret_key" { default = "INSERT_SECRET_ACCESS_KEY_HERE" }
 variable "instance_type" { default = "t1.micro" }
 variable "region" { default = "us-east-1" }
 variable "ami" { default = "ami-408c7f28" }
+variable "security_groups" { default = [] }
+
+output "url" {
+	value = "${aws_instance.petclinic.public_dns}:9966/petclinic"
+}


### PR DESCRIPTION
- User can now edit the security groups for aws instances
- Instance URL is output to user when created
- Server is created in background on AWS instance so user can view output variables after provisioning
- Heavily modified terraform setup documentation to include steps about downloading Java and Maven